### PR TITLE
Added financial_year and financial_year_exact

### DIFF
--- a/cores/budgetportal/conf/schema.xml
+++ b/cores/budgetportal/conf/schema.xml
@@ -93,6 +93,10 @@
     
     <field name="government_label_exact" type="string" indexed="true" stored="true" multiValued="false" />
     
+    <field name="financial_year" type="text_en" indexed="true" stored="true" multiValued="false" />
+    
+    <field name="financial_year_exact" type="string" indexed="true" stored="true" multiValued="false" />
+    
     <field name="sphere" type="text_en" indexed="true" stored="true" multiValued="false" />
     
     <field name="sphere_exact" type="string" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
This is needed for the `search-by-appropriation` branch on `datamanager` repo.